### PR TITLE
Estimate price tests

### DIFF
--- a/app/wasm/queries.go
+++ b/app/wasm/queries.go
@@ -71,7 +71,10 @@ func (qp QueryPlugin) EstimatePrice(ctx sdk.Context, estimatePrice *bindings.Est
 		return nil, wasmvmtypes.UnsupportedRequest{Kind: "TODO: multi-hop swap price estimation"}
 	}
 
-	var senderAddress = sdk.AccAddress(sender)
+	senderAddress, err := sdk.AccAddressFromBech32(sender)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "gamm estimate price sender address")
+	}
 
 	if estimatePrice.Amount.In != nil {
 		tokenIn := sdk.NewCoin(denomIn, *estimatePrice.Amount.In)

--- a/app/wasm/test/custom_query_test.go
+++ b/app/wasm/test/custom_query_test.go
@@ -176,7 +176,7 @@ func TestQuerySpotPrice(t *testing.T) {
 func TestQueryEstimatePrice(t *testing.T) {
 	actor := RandomAccountAddress()
 	osmosis, ctx := SetupCustomApp(t, actor)
-	epsilon := 1. // high epsilon (because of rounding?)
+	epsilon := 1e-3
 
 	fundAccount(t, ctx, osmosis, actor, defaultFunds)
 
@@ -201,7 +201,7 @@ func TestQueryEstimatePrice(t *testing.T) {
 	swapRate := ustar / uosmo
 
 	// Query estimate cost (Exact in. No route)
-	amountIn := sdk.NewInt(1)
+	amountIn := sdk.NewInt(10000)
 	query := wasmbindings.OsmosisQuery{
 		EstimatePrice: &wasmbindings.EstimatePrice{
 			Contract: reflect.String(),
@@ -230,14 +230,14 @@ func TestQueryEstimatePrice(t *testing.T) {
 
 	// And the other way around
 	// Query estimate cost (Exact out. No route)
-	amountOut := sdk.NewInt(1)
+	amountOut := sdk.NewInt(10000)
 	query = wasmbindings.OsmosisQuery{
 		EstimatePrice: &wasmbindings.EstimatePrice{
 			Contract: reflect.String(),
 			First: wasmbindings.Swap{
 				PoolId:   starPool,
-				DenomIn:  "ustar",
-				DenomOut: "uosmo",
+				DenomIn:  "uosmo",
+				DenomOut: "ustar",
 			},
 			Route: []wasmbindings.Step{},
 			Amount: wasmbindings.SwapAmount{
@@ -252,14 +252,9 @@ func TestQueryEstimatePrice(t *testing.T) {
 	cost, err = (*resp.Amount.In).ToDec().Float64()
 	require.NoError(t, err)
 
-	uosmo, err = poolFunds[0].Amount.ToDec().Float64()
-	require.NoError(t, err)
-	ustar, err = poolFunds[1].Amount.ToDec().Float64()
-	require.NoError(t, err)
-
 	amount, err = amountOut.ToDec().Float64()
 	require.NoError(t, err)
-	expected = amount * swapRate
+	expected = amount * 1. / swapRate
 	require.InEpsilonf(t, expected, cost, epsilon, fmt.Sprintf("Outside of tolerance (%f)", epsilon))
 }
 

--- a/app/wasm/test/custom_query_test.go
+++ b/app/wasm/test/custom_query_test.go
@@ -173,6 +173,97 @@ func TestQuerySpotPrice(t *testing.T) {
 	require.InEpsilonf(t, expected+swapFee, price, epsilon, fmt.Sprintf("Outside of tolerance (%f)", epsilon))
 }
 
+func TestQueryEstimatePrice(t *testing.T) {
+	actor := RandomAccountAddress()
+	osmosis, ctx := SetupCustomApp(t, actor)
+	epsilon := 1. // high epsilon (because of rounding?)
+
+	fundAccount(t, ctx, osmosis, actor, defaultFunds)
+
+	poolFunds := []sdk.Coin{
+		sdk.NewInt64Coin("uosmo", 12000000),
+		sdk.NewInt64Coin("ustar", 240000000),
+	}
+	// 20 star to 1 osmo
+	starPool := preparePool(t, ctx, osmosis, actor, poolFunds)
+
+	reflect := instantiateReflectContract(t, ctx, osmosis, actor)
+	require.NotEmpty(t, reflect)
+
+	// FIXME: The contract needs to have funds for estimating the price...
+	// Plus, a "query" shouldn't be changing state / generating transactions...
+	fundAccount(t, ctx, osmosis, reflect, defaultFunds)
+
+	// Estimate swap rate
+	uosmo, err := poolFunds[0].Amount.ToDec().Float64()
+	require.NoError(t, err)
+	ustar, err := poolFunds[1].Amount.ToDec().Float64()
+	require.NoError(t, err)
+	swapRate := ustar / uosmo
+
+	// Query estimate cost (Exact in. No route)
+	amountIn := sdk.NewInt(1)
+	query := wasmbindings.OsmosisQuery{
+		EstimatePrice: &wasmbindings.EstimatePrice{
+			Contract: reflect.String(),
+			First: wasmbindings.Swap{
+				PoolId:   starPool,
+				DenomIn:  "uosmo",
+				DenomOut: "ustar",
+			},
+			Route: []wasmbindings.Step{},
+			Amount: wasmbindings.SwapAmount{
+				In: &amountIn,
+			},
+		},
+	}
+	resp := wasmbindings.EstimatePriceResponse{}
+	queryCustom(t, ctx, osmosis, reflect, query, &resp)
+	require.NotNil(t, resp.Amount.Out)
+	require.Nil(t, resp.Amount.In)
+	cost, err := (*resp.Amount.Out).ToDec().Float64()
+	require.NoError(t, err)
+
+	amount, err := amountIn.ToDec().Float64()
+	require.NoError(t, err)
+	expected := amount * swapRate // out
+	require.InEpsilonf(t, expected, cost, epsilon, fmt.Sprintf("Outside of tolerance (%f)", epsilon))
+
+	// And the other way around
+	// Query estimate cost (Exact out. No route)
+	amountOut := sdk.NewInt(1)
+	query = wasmbindings.OsmosisQuery{
+		EstimatePrice: &wasmbindings.EstimatePrice{
+			Contract: reflect.String(),
+			First: wasmbindings.Swap{
+				PoolId:   starPool,
+				DenomIn:  "ustar",
+				DenomOut: "uosmo",
+			},
+			Route: []wasmbindings.Step{},
+			Amount: wasmbindings.SwapAmount{
+				Out: &amountOut,
+			},
+		},
+	}
+	resp = wasmbindings.EstimatePriceResponse{}
+	queryCustom(t, ctx, osmosis, reflect, query, &resp)
+	require.NotNil(t, resp.Amount.In)
+	require.Nil(t, resp.Amount.Out)
+	cost, err = (*resp.Amount.In).ToDec().Float64()
+	require.NoError(t, err)
+
+	uosmo, err = poolFunds[0].Amount.ToDec().Float64()
+	require.NoError(t, err)
+	ustar, err = poolFunds[1].Amount.ToDec().Float64()
+	require.NoError(t, err)
+
+	amount, err = amountOut.ToDec().Float64()
+	require.NoError(t, err)
+	expected = amount * swapRate
+	require.InEpsilonf(t, expected, cost, epsilon, fmt.Sprintf("Outside of tolerance (%f)", epsilon))
+}
+
 type ReflectQuery struct {
 	Chain *ChainRequest `json:"chain,omitempty"`
 }

--- a/app/wasm/test/custom_query_test.go
+++ b/app/wasm/test/custom_query_test.go
@@ -190,8 +190,7 @@ func TestQueryEstimatePrice(t *testing.T) {
 	reflect := instantiateReflectContract(t, ctx, osmosis, actor)
 	require.NotEmpty(t, reflect)
 
-	// FIXME: The contract needs to have funds for estimating the price...
-	// Plus, a "query" shouldn't be changing state / generating transactions...
+	// The contract/sender needs to have funds for estimating the price
 	fundAccount(t, ctx, osmosis, reflect, defaultFunds)
 
 	// Estimate swap rate


### PR DESCRIPTION
Some integration tests of the `EstimatePrice` query.

These tests require the "sender" account to have funds, so that price estimation can proceed... the "estimation" also sends coins, that is, (afaik) **it performs the swap** between the sender account and the pool module.

There are a number of issues here:

- Queries shouldn't change state / generate transactions.
- Sender is an arbitrary string field in the message. That means this "query" could be used (afaik) to **perform swaps on behalf of other people's accounts**.